### PR TITLE
Updated branch version workflow and README

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
     # Set the version in the csproj file based on the extracted version number
     - name: Set version in csproj
       run: |
-        $csprojPath = "../../Cohere/Cohere.csproj"
+        $csprojPath = "../Cohere/Cohere.csproj"
         (Get-Content $csprojPath) -replace '<VersionPrefix>.*</VersionPrefix>', "<VersionPrefix>${{ env.VersionNumber }}</VersionPrefix>" | Set-Content $csprojPath
 
     # Build the project in Release configuration

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch: # Allow running the workflow manually from the GitHub UI
   push:
     branches:
-      - 'main'       # Run the workflow when pushing to the main branch
+      - 'release/*'  # Run the workflow when pushing to release branches like release/{VersionNumber}
   pull_request:
     branches:
       - '*'          # Run the workflow for all pull requests
@@ -30,11 +30,27 @@ jobs:
       with:
         fetch-depth: 0 # Get all history to allow automatic versioning using MinVer
 
+    - name: Extract version from branch name
+      if: startsWith(github.ref_name, 'release/')
+      id: extract_version
+      run: |
+        # Get version from the branch name, e.g., release/v0.9-beta1
+        $branchName = '${{ github.ref_name }}'
+        $version = $branchName -replace 'release/', ''
+        Write-Output "Version: $version"
+        echo "VersionNumber=$version" >> $env:GITHUB_ENV
+
     # Install the .NET SDK indicated in the global.json file
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
 
-    # Create the NuGet package in the folder from the environment variable NuGetDirectory
+    # Set the version in the csproj file based on the extracted version number
+    - name: Set version in csproj
+      run: |
+        $csprojPath = "../../Cohere/Cohere.csproj"
+        (Get-Content $csprojPath) -replace '<VersionPrefix>.*</VersionPrefix>', "<VersionPrefix>${{ env.VersionNumber }}</VersionPrefix>" | Set-Content $csprojPath
+
+    # Build the project in Release configuration
     - run: dotnet build --configuration Release
 
     # Create the NuGet package in the folder from the environment variable NuGetDirectory

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
     # Set the version in the csproj file based on the extracted version number
     - name: Set version in csproj
       run: |
-        $csprojPath = "../Cohere/Cohere.csproj"
+        $csprojPath = "Cohere/Cohere.csproj"
         (Get-Content $csprojPath) -replace '<VersionPrefix>.*</VersionPrefix>', "<VersionPrefix>${{ env.VersionNumber }}</VersionPrefix>" | Set-Content $csprojPath
 
     # Build the project in Release configuration

--- a/Cohere.Tests/CohereStepDefinitions.cs
+++ b/Cohere.Tests/CohereStepDefinitions.cs
@@ -17,6 +17,11 @@ public partial class CohereStepDefinitions
     private readonly string _apiKey = "test-api-key";
     private Exception? _caughtException;
     
+    public CohereStepDefinitions(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+    
     /// <summary>
     /// Verifies that an API key is available for testing
     /// Since no call to the API is made, the API key is not validated

--- a/Cohere/Cohere.csproj
+++ b/Cohere/Cohere.csproj
@@ -7,7 +7,7 @@
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
         <PackageId>Cohere.NET</PackageId>
-        <VersionPrefix>0.9-beta1</VersionPrefix>
+        <VersionPrefix>$(VersionNumber)</VersionPrefix>
         <Authors>Apption</Authors>
         <Company>Apption</Company>
         <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 - Classify
 - Rerank
 
+## Latest Builds
+
+|                  | Stable                                                                                                                        | Build status                                                                                                                                                                                                                     |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Cohere .NET      | [![NuGet Version](https://img.shields.io/nuget/v/Cohere.NET.svg?logo=nuget)](https://www.nuget.org/packages/Cohere.NET)       | [![publish](https://github.com/apption-oscode/cohere-dotnet/actions/workflows/main.yml/badge.svg)](https://github.com/apption-oscode/cohere-dotnet/actions/workflows/main.yml)                                                   |
+
 ## Installation
 
 You can install the SDK via NuGet:


### PR DESCRIPTION
- Updated version workflow so that it works in the following way:

     - Create a release branch with the name ```release/v*```
     - Github workflow takes the version number and updates Cohere.csproj with the corresponding number ```v*```
     - Nuget package is created and deployed using the version number set in the release branch name
    
- Added ```Latest Builds``` section to README so that it links to the Nuget package and shows the status of the ```publish``` workflow